### PR TITLE
Patch paths in default configuration for Flatpak

### DIFF
--- a/org.zdoom.Raze.appdata.xml
+++ b/org.zdoom.Raze.appdata.xml
@@ -43,7 +43,7 @@
   </screenshots>
 
   <releases>
-    <release version="1.1.2" date="2021-05-14">
+    <release version="1.4.1" date="2022-01-22">
       <description>
         <p>First release of Raze on Flatpak.</p>
       </description>

--- a/org.zdoom.Raze.desktop
+++ b/org.zdoom.Raze.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Comment=Multi-game launcher for Build engine games
 Categories=Game;Shooter;
-Exec=raze.sh
+Exec=raze
 Icon=org.zdoom.Raze
 Name=Raze
 StartupNotify=true

--- a/org.zdoom.Raze.yaml
+++ b/org.zdoom.Raze.yaml
@@ -2,7 +2,7 @@ app-id: org.zdoom.Raze
 runtime: org.freedesktop.Platform
 sdk: org.freedesktop.Sdk
 runtime-version: "21.08"
-command: raze.sh
+command: raze
 
 finish-args:
 - --device=dri
@@ -54,16 +54,14 @@ modules:
     url: https://github.com/coelckers/raze.git
     tag: 1.4.1
     commit: c756ce7ef80cf39912e61d71928236146a94f87b
+  - type: patch
+    path: raze-flatpak-paths.patch
   post-install:
-  - install -Dm 644 soundfont/raze.sf2 /app/share/sounds/sf2/raze.sf2
+  - install -Dm 644 soundfont/raze.sf2 /app/share/games/raze/soundfonts/raze.sf2
 
-- name: launcher
+- name: integration
   buildsystem: simple
   sources:
-  - type: script
-    commands:
-    - raze +fluid_patchset /app/share/sounds/sf2/raze.sf2 "$@"
-    dest-filename: raze.sh
   - type: file
     path: org.zdoom.Raze.desktop
   - type: file
@@ -77,7 +75,6 @@ modules:
   - type: file
     path: org.zdoom.Raze.256.png
   build-commands:
-  - install -D raze.sh /app/bin/raze.sh
   - install -Dm 644 org.zdoom.Raze.desktop -t /app/share/applications
   - install -Dm 644 org.zdoom.Raze.appdata.xml -t /app/share/metainfo
   - install -Dm 644 org.zdoom.Raze.32.png /app/share/icons/hicolor/32x32/apps/org.zdoom.Raze.png

--- a/org.zdoom.Raze.yaml
+++ b/org.zdoom.Raze.yaml
@@ -52,8 +52,8 @@ modules:
   sources:
   - type: git
     url: https://github.com/coelckers/raze.git
-    tag: 1.1.2
-    commit: d26d3f051341e5c4cc487050c1f144ae168396cb
+    tag: 1.4.1
+    commit: c756ce7ef80cf39912e61d71928236146a94f87b
   post-install:
   - install -Dm 644 soundfont/raze.sf2 /app/share/sounds/sf2/raze.sf2
 

--- a/raze-flatpak-paths.patch
+++ b/raze-flatpak-paths.patch
@@ -1,0 +1,63 @@
+diff '--color=auto' -ruN old/source/core/gameconfigfile.cpp new/source/core/gameconfigfile.cpp
+--- old/source/core/gameconfigfile.cpp	2022-01-30 09:08:23.000000000 +0100
++++ new/source/core/gameconfigfile.cpp	2022-03-03 18:37:17.240806424 +0100
+@@ -101,19 +101,7 @@
+ 		// Arch Linux likes them in /usr/share/raze
+ 		// Debian likes them in /usr/share/games/raze
+ 		// I assume other distributions don't do anything radically different
+-		SetValueForKey ("Path", "/opt/raze", true);
+-		SetValueForKey ("Path", "/usr/share/games/raze", true);
+-		SetValueForKey ("Path", "/usr/local/share/games/raze", true);
+-		SetValueForKey ("Path", "/usr/share/games/jfduke3d", true);
+-		SetValueForKey ("Path", "/usr/local/share/games/jfduke3d", true);
+-		SetValueForKey ("Path", "/usr/share/games/eduke32", true);
+-		SetValueForKey ("Path", "/usr/local/share/games/eduke32", true);
+-		SetValueForKey ("Path", "/usr/share/games/nblood", true);
+-		SetValueForKey ("Path", "/usr/local/share/games/nblood", true);
+-		SetValueForKey("Path", "/usr/share/games/jfsw", true);
+-		SetValueForKey("Path", "/usr/local/share/games/jfsw", true);
+-		SetValueForKey("Path", "/usr/share/games/voidsw", true);
+-		SetValueForKey("Path", "/usr/local/share/games/voidsw", true);
++		SetValueForKey ("Path", "/app/share/games/raze", true);
+ 
+ #endif
+ 		SetValueForKey ("Path", "$STEAM", true); // also covers GOG.
+@@ -133,13 +121,7 @@
+ 		SetValueForKey ("Path", "$GAMEDIR", true);
+ #else
+ 		SetValueForKey ("Path", "$HOME/" GAME_DIR, true);
+-		SetValueForKey ("Path", SHARE_DIR, true);
+-		SetValueForKey ("Path", "/usr/share/games/jfduke3d", true);
+-		SetValueForKey ("Path", "/usr/local/share/games/jfduke3d", true);
+-		SetValueForKey ("Path", "/usr/share/games/eduke32", true);
+-		SetValueForKey ("Path", "/usr/local/share/games/eduke32", true);
+-		SetValueForKey ("Path", "/usr/share/games/nblood", true);
+-		SetValueForKey ("Path", "/usr/local/share/games/nblood", true);
++		SetValueForKey ("Path", "/app/share/games/raze", true);
+ #endif
+ 	}
+ 
+@@ -156,10 +138,7 @@
+ 		SetValueForKey("Path", "$PROGDIR/soundfonts", true);
+ #else
+ 		SetValueForKey("Path", "$HOME/" GAME_DIR "/soundfonts", true);
+-		SetValueForKey("Path", "/usr/local/share/" GAME_DIR "/soundfonts", true);
+-		SetValueForKey("Path", "/usr/local/share/games/" GAME_DIR "/soundfonts", true);
+-		SetValueForKey("Path", "/usr/share/" GAME_DIR "/soundfonts", true);
+-		SetValueForKey("Path", "/usr/share/games/" GAME_DIR "/soundfonts", true);
++		SetValueForKey("Path", "/app/share/games/raze/soundfonts", true);
+ #endif
+ 	}
+ 
+diff '--color=auto' -ruN old/source/core/gamecontrol.cpp new/source/core/gamecontrol.cpp
+--- old/source/core/gamecontrol.cpp	2022-01-30 09:08:23.000000000 +0100
++++ new/source/core/gamecontrol.cpp	2022-03-03 18:40:25.138790450 +0100
+@@ -669,7 +669,7 @@
+ #ifdef WIN32
+ 		);
+ #else
+-		"\nInstall game data files in subfolders of '%s'\n\n", M_GetAppDataPath(false).GetChars());
++		"\nInstall game data files in subfolders of '%s'\n\n", "~/.var/app/org.zdoom.Raze/" GAME_DIR);
+ #endif
+ 	}
+ 


### PR DESCRIPTION
If the file `~/.var/app/org.zdoom.Raze/.config/raze/raze.ini` already exists, it must be deleted for the fix to work.